### PR TITLE
Minor updates for ease of use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+node_modules

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+all: install
+
+install:
+	npm i express combohandler stache
+

--- a/app.js
+++ b/app.js
@@ -3,6 +3,8 @@
 var combo = require('combohandler'),
     express = require('express'),
     stache = require('stache'),
+    seed = require('./lib/seed'),
+    stamp = 'yui3-nightly',
     app = express.createServer();
 
 app.configure(function() {
@@ -26,6 +28,12 @@ app.get('/', function(req, res) {
     res.render('index', {});
 });
 app.get('/yui', combo.combine({rootPath: 'build/www'}), function (req, res) {
+    res.body = res.body.replace(/@VERSION@/g, stamp);
+    res.send(res.body, 200);
+});
+
+app.get('/seed', seed.stamp({rootPath: 'build/www'}), function (req, res) {
+    res.body = res.body.replace(/@VERSION@/g, stamp);
     res.send(res.body, 200);
 });
 

--- a/lib/seed.js
+++ b/lib/seed.js
@@ -1,0 +1,47 @@
+
+var path = require('path'),
+    fs = require('fs');
+    root = '',
+    seeds = {
+        min: '',
+        raw: '',
+        debug: ''
+    };
+
+
+module.exports = {
+    stamp: function(o) {
+        root = path.join(__dirname, '../', o.rootPath);
+
+        if (!path.existsSync(root)) {
+            throw('Root path does not exist');
+        }
+        
+        //All the seed files
+        seeds['min'] = fs.readFileSync(path.join(root, 'yui/yui-min.js'), 'utf8');
+        seeds['raw'] = fs.readFileSync(path.join(root, 'yui/yui.js'), 'utf8');
+        seeds['debug'] = fs.readFileSync(path.join(root, 'yui/yui-debug.js'), 'utf8');
+
+        return function(req, res, next) {
+            //Set the filter type for the seed fetch
+            var filt = seeds[req.query.filter] ? req.query.filter : 'min',
+                
+                //Stamp the seed config and version
+                seedStamp = '\n\n/* Stamping Seed File */\n' + 
+                'YUI.applyConfig({\n' + 
+                '   comboBase: "http://' + req.headers.host + '/yui?",\n' + 
+                '   root: "",\n' + 
+                '   filter: "' + filt + '"\n' + 
+                '});\n' + 
+                '\nYUI.version = "yui3-nightly";';
+            
+            //Concat the file with the stamp
+            res.body = seeds[filt] + seedStamp;
+            //Set the content type
+            res.contentType('.js');
+            //Send to next route
+            next();
+
+        }
+    }
+}

--- a/static/style.css
+++ b/static/style.css
@@ -9,7 +9,6 @@ div {
     margin: .5em 0;
 }
 pre {
-    width: 70%;
     border: 1px solid #333;
     line-height: 1.5hm;
     background-color: #ccc;

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+    <title>Nightly test</title>
+</head>
+<body>
+
+
+<script src="http://127.0.0.1:8082/seed"></script>
+<script>
+YUI().use('node', function(Y) {
+    Y.one('body').setStyle('backgroundColor', 'green');
+});
+</script>
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -6,7 +6,7 @@
 <body>
 
 
-<script src="http://127.0.0.1:8082/seed"></script>
+<script src="http://127.0.0.1:8082/seed?filter=debug"></script>
 <script>
 YUI().use('node', function(Y) {
     Y.one('body').setStyle('backgroundColor', 'green');

--- a/views/index.mustache
+++ b/views/index.mustache
@@ -9,13 +9,20 @@ releases.</div>
 source tree is built and served from /yui.  All you need to do is to point your
 YUI object to the nightly combo loader.</div>
 
-<div>Add the following code to your main template before any calls to
-<code>YUI().use()</code>.</div>
+<div>To use this, simply use this as your seed file:</div>
 
-<pre><code>YUI_config = {
-  comboBase: 'http://yuinightly.kludg.com/yui?',
-  root: ''
-};</code></pre>
+<pre><code>
+&lt;script src="http://yuinightly.kludg.com/seed"&gt;&lt;/script&gt;
+</code></pre>
+
+<div>
+The seed file also supports the 3 default YUI filter's: <code>min, raw, filter</code>
+</div>
+<pre><code>
+&lt;script src="http://yuinightly.kludg.com/seed?filter=min"&gt;&lt;/script&gt;
+&lt;script src="http://yuinightly.kludg.com/seed?filter=raw"&gt;&lt;/script&gt;
+&lt;script src="http://yuinightly.kludg.com/seed?filter=debug"&gt;&lt;/script&gt;
+</code></pre>
 
 <div><strong>Note:</strong> Do this in a development instance. If you point
 production to this development code, you deserve everything you get.</div>


### PR DESCRIPTION
First, added a /seed entry point that supports `?filter=min|raw|debug`, it also auto writes the global YUI config to set the comboBase to the hostname that it's served from.

Second, had the combo and seed auto replace @VERSION@ with yui3-nightly so that it's stamped properly. We could probably write this dynamically with the date like: 'yui3-2011.12.14' or something like that so they user can see the actual date this is from. We could even write an entry point like /2011.12.14/seed and have that auto set the seed and comboBase
